### PR TITLE
unexpected error message

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerCallableStatement.java
@@ -1450,6 +1450,8 @@ public class SQLServerCallableStatement extends SQLServerPreparedStatement imple
         int l = 0;
         if (paramNames != null)
             l = paramNames.size();
+        if (l == 0)//Server didn't return anything, user might not have access
+        	return 1;//attempting to look up the first column will return no access exception
 
         // handle `@name` as well as `name`, since `@name` is what's returned 
         // by DatabaseMetaData#getProcedureColumns


### PR DESCRIPTION
don't attempt mismatch logic if there's no columns to look for. fall through to sql server and do a lookup on the first column.